### PR TITLE
Change UI thread naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,13 @@ const test = async () => {
 test();
 ```
 
-3. Open the JSON file generated in the web profiler:
+3. Run your test:
+
+```sh
+yarn jest yourtest
+```
+
+4. Open the JSON file generated in the web profiler:
 
 ```sh
 yarn generate-performance-web-report results.json

--- a/packages/android-performance-profiler/src/commands/__tests__/detectCurrentAppBundleId.test.ts
+++ b/packages/android-performance-profiler/src/commands/__tests__/detectCurrentAppBundleId.test.ts
@@ -4,16 +4,35 @@ const sampleOutput = `
 mSurface=Surface(name=com.example.staging/com.example.MainActivity$_9617)/@0x993d3ae
 mSurface=Surface(name=com.sec.android.app.launcher/com.sec.android.app.launcher.activities.LauncherActivity$_3088)/@0x469a915`;
 
+const sampleOutputWithoutDollars = `
+mSurface=Surface(name=com.example.staging/com.example.MainActivity)/@0x993d3ae
+mSurface=Surface(name=com.sec.android.app.launcher/com.sec.android.app.launcher.activities.LauncherActivity)/@0x469a915`;
+
 const executeCommandSpy = jest.spyOn(require("../shell"), "executeCommand");
 
 describe("detectCurrentAppBundleId", () => {
-  it("retrieves correctly bundle id and app activity", () => {
+  it("retrieves correctly bundle id and app activity when result match 'name=appId/appActivity$'", () => {
     executeCommandSpy.mockImplementation((command) => {
       expect(command).toEqual(
         "adb shell dumpsys window windows | grep -E 'mCurrentFocus|mFocusedApp|mInputMethodTarget|mSurface' | grep Activity"
       );
 
       return sampleOutput;
+    });
+
+    expect(detectCurrentAppBundleId()).toEqual({
+      bundleId: "com.example.staging",
+      appActivity: "com.example.MainActivity",
+    });
+  });
+
+  it("retrieves correctly bundle id and app activity when result match 'name=appId/appActivity)'", () => {
+    executeCommandSpy.mockImplementation((command) => {
+      expect(command).toEqual(
+        "adb shell dumpsys window windows | grep -E 'mCurrentFocus|mFocusedApp|mInputMethodTarget|mSurface' | grep Activity"
+      );
+
+      return sampleOutputWithoutDollars;
     });
 
     expect(detectCurrentAppBundleId()).toEqual({

--- a/packages/android-performance-profiler/src/commands/cpu/getCpuStatsByProcess.ts
+++ b/packages/android-performance-profiler/src/commands/cpu/getCpuStatsByProcess.ts
@@ -8,7 +8,7 @@ export interface ProcessStat {
 export const getCommand = (pid: string): string =>
   `cd /proc/${pid}/task && ls | tr '\n' ' ' | sed 's/ /\\/stat /g' | xargs cat $1`;
 
-export const processOutput = (output: string): ProcessStat[] =>
+export const processOutput = (output: string, pid: string): ProcessStat[] =>
   output
     .split("\n")
     .filter(Boolean)
@@ -16,7 +16,7 @@ export const processOutput = (output: string): ProcessStat[] =>
     .filter(Boolean)
     .map((subProcessStats) => {
       const processId = subProcessStats[0];
-      const processName = subProcessStats[1];
+      const processName = processId === pid ? "UI Thread" : subProcessStats[1];
       const utime = parseInt(subProcessStats[13], 10);
       const stime = parseInt(subProcessStats[14], 10);
       const cutime = parseInt(subProcessStats[15], 10);

--- a/packages/android-performance-profiler/src/commands/detectCurrentAppBundleId.ts
+++ b/packages/android-performance-profiler/src/commands/detectCurrentAppBundleId.ts
@@ -6,7 +6,7 @@ export const detectCurrentAppBundleId = () => {
 
   const commandOutput = executeCommand(command);
 
-  const regexMatching = commandOutput.match(/name=([\w.]+)\/([\w.]+)\$/);
+  const regexMatching = commandOutput.match(/name=([\w.]+)\/([\w.]+)\$?/);
 
   if (!regexMatching) {
     throw new Error(

--- a/packages/android-performance-profiler/src/commands/pollPerformanceMeasures.ts
+++ b/packages/android-performance-profiler/src/commands/pollPerformanceMeasures.ts
@@ -18,7 +18,7 @@ export const pollPerformanceMeasures = (
   return cppPollPerformanceMeasures(
     pid,
     ({ cpu, ram: ramStr, gfxinfo, timestamp, adbExecTime }) => {
-      const subProcessesStats = processOutput(cpu);
+      const subProcessesStats = processOutput(cpu, pid);
 
       const ram = processRamOutput(ramStr);
       const fps = processFpsOutput(gfxinfo);


### PR DESCRIPTION
Closes #15 

Duplicate of #18 to run CI on this repo.

# Description

The goal is to replace "com.app.any" in the Threads View by "UI Thread".

~~I wanted to use `detectCurrentAppBundleId` in `packages/android-performance-profiler/src/commands/cpu/getCpuStatsByProcess.ts` but it crashed the e2e-test because the app was not detected each time the function was called. I think it is because we close and open the app a lot during our tests.~~

~~So I pass the bundle id in params. I don't know if this is the cleanest way.~~

It was not working for big bundle id like `com.facebook.katana` or bigger. So, I used an other method that is to compare `processId` and `pid`. If these ids are the same, it is the main thread and we write "UI thread".

# Test plan

I manually tested the result on the reporter and it works fine!
<img width="193" alt="image" src="https://user-images.githubusercontent.com/40902940/187926074-b3845baf-7c85-4170-bb51-6e1d52eef4e4.png">

I also ran tests and updated snapshot.

I don't know how I can manually test `flipper-plugin-android-performance-profiler` so if you know how to do it I can try.