### PR TITLE
fix(web-reporter): fix running web-reporter with absolute path

### DIFF
--- a/packages/web-reporter/openReport.ts
+++ b/packages/web-reporter/openReport.ts
@@ -33,16 +33,15 @@ const getJsonPaths = () => {
 
   return paths
     .map((path) => {
-      const fullPath = `${process.cwd()}/${path}`;
-      const isDirectory = fs.lstatSync(fullPath).isDirectory();
+      const isDirectory = fs.lstatSync(path).isDirectory();
 
       if (isDirectory) {
         return fs
-          .readdirSync(fullPath)
+          .readdirSync(path)
           .filter((file) => file.endsWith(".json"))
-          .map((file) => `${fullPath}/${file}`);
+          .map((file) => `${path}/${file}`);
       } else {
-        return fullPath;
+        return path;
       }
     })
     .flat();


### PR DESCRIPTION
Using `process.cwd()` was unnecessary, plus it was breaking absolute paths

For instance when running `npx @perf-profiler/web-reporter /tmp/my-folder`, the script would try to open `/Users/almouro/dev/projects/my-project//tmp/my-folder` instead of `tmp/my-folder` directly