### PR TITLE
fix(adb): replace start command by monkey

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,12 @@ import { TestCase, measurePerformance } from "@perf-profiler/e2e";
 
 // `npx @perf-profiler/profiler getCurrentApp` will display info for the current app
 const bundleId = "com.reactnativefeed";
-const appActivity = `${bundleId}.MainActivity`;
 
 const stopApp = () => execSync(`adb shell am force-stop ${bundleId}`);
 const startApp = () =>
-  execSync(`adb shell am start ${bundleId}/${appActivity}`);
+  execSync(
+    `adb shell monkey -p ${bundleId} -c android.intent.category.LAUNCHER 1`
+  );
 
 const startTestCase: TestCase = {
   duration: 10000,

--- a/packages/appium-helper/AppiumDriver.ts
+++ b/packages/appium-helper/AppiumDriver.ts
@@ -81,7 +81,9 @@ export class AppiumDriver {
   }
 
   startApp() {
-    executeCommand(`adb shell am start ${this.bundleId}/${this.appActivity}`);
+    executeCommand(
+      `adb shell monkey -p ${this.bundleId} -c android.intent.category.LAUNCHER 1`
+    );
   }
 
   restartApp() {

--- a/packages/e2e-example/basic.ts
+++ b/packages/e2e-example/basic.ts
@@ -2,11 +2,12 @@ import { execSync } from "child_process";
 import { TestCase, measurePerformance } from "@perf-profiler/e2e";
 
 const bundleId = "com.reactnativefeed";
-const appActivity = `${bundleId}.MainActivity`;
 
 const stopApp = () => execSync(`adb shell am force-stop ${bundleId}`);
 const startApp = () =>
-  execSync(`adb shell am start ${bundleId}/${appActivity}`);
+  execSync(
+    `adb shell monkey -p ${bundleId} -c android.intent.category.LAUNCHER 1`
+  );
 
 const startTestCase: TestCase = {
   duration: 10000,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7242,7 +7242,7 @@ flipper-pkg-lib@0.140.0:
     metro-minify-terser "^0.66.2"
     npm-packlist "^4.0.0"
 
-flipper-pkg@latest:
+flipper-pkg@0.140.0:
   version "0.140.0"
   resolved "https://registry.yarnpkg.com/flipper-pkg/-/flipper-pkg-0.140.0.tgz#3a2b3654c98bf4b76c7efa62c56b0a4deeb438f8"
   integrity sha512-VnfsmVA1tD6xscC4iUATzXmjps+5wEHxwtbheV7OaZeA3HCx8IbecfI1UqYpwKfq0Z3mPhOhd7CuigmWSg2q4w==
@@ -7280,7 +7280,7 @@ flipper-plugin-lib@0.140.0:
     semver "^7.3.5"
     tmp "^0.2.1"
 
-flipper-plugin@latest:
+flipper-plugin@0.140.0:
   version "0.140.0"
   resolved "https://registry.yarnpkg.com/flipper-plugin/-/flipper-plugin-0.140.0.tgz#b918193643ac3e402dbb8f86b9a3420cbaa1c227"
   integrity sha512-QckTvMzfjWgWdk51galhjHexGB4YfxHNddwvRpuCMc7DmTRHJFV2ZHFKUuZW3bq1eYWb1FqcFRNVmaZ1fzVubA==


### PR DESCRIPTION
Closes #21 

With monkey command, we don't need to specify AppActivity to start the app. It avoid security exceptions when we don't know the good AppActivity.

It doesn't seem slower:
| Before | Now |
| ------  |  ---- |
| <img width="262" alt="Capture d’écran 2022-09-19 à 01 56 34" src="https://user-images.githubusercontent.com/40902940/190933902-73527bdc-6266-47be-bc84-67bd47eb014b.png"> | <img width="259" alt="Capture d’écran 2022-09-19 à 01 53 38" src="https://user-images.githubusercontent.com/40902940/190933913-738acb83-0aab-4e9a-8976-a90c5babd64b.png"> |

And the test doesn't seem broken:
![localhost_1234_](https://user-images.githubusercontent.com/40902940/190934007-b1d801e0-3a54-4f04-9dbe-5ab63784e3f8.png)
