### PR TITLE
fix(web-reporter-ui): remove the uncentered font

### DIFF
--- a/packages/flipper-plugin-android-performance-profiler/package.json
+++ b/packages/flipper-plugin-android-performance-profiler/package.json
@@ -49,8 +49,8 @@
     "@types/react": "^17.0.2",
     "@types/react-dom": "latest",
     "antd": "latest",
-    "flipper-pkg": "latest",
-    "flipper-plugin": "latest",
+    "flipper-pkg": "0.140.0",
+    "flipper-plugin": "0.140.0",
     "react-dom": "^17.0.2"
   }
 }

--- a/packages/flipper-plugin-android-performance-profiler/src/__tests__/__snapshots__/Plugin.ts.snap
+++ b/packages/flipper-plugin-android-performance-profiler/src/__tests__/__snapshots__/Plugin.ts.snap
@@ -333,11 +333,11 @@ exports[`displays FPS data and scoring 2`] = `
                     </svg>
                   </span>
                   <div
-                    class="MuiBox-root css-1mo2re"
+                    class="MuiBox-root css-1o8dslu"
                   >
                     <div
                       class="MuiTypography-root MuiTypography-caption css-4ii6uc-MuiTypography-root"
-                      style="font-size: 28px; color: rgb(255, 65, 54); font-family: josefin-sans, sans-serif;"
+                      style="font-size: 28px; color: rgb(255, 65, 54);"
                     >
                       45
                     </div>

--- a/packages/web-reporter-ui/components/CircularProgressWithLabel.tsx
+++ b/packages/web-reporter-ui/components/CircularProgressWithLabel.tsx
@@ -13,8 +13,8 @@ export const CircularProgressWithLabel = ({
     <Box position="relative" display="inline-flex">
       <CircularProgress variant="determinate" {...props} style={{ color }} />
       <Box
-        top={(props.size / 80) * 6}
-        left={(props.size / 80) * 3}
+        top={0}
+        left={0}
         bottom={0}
         right={0}
         position="absolute"
@@ -29,7 +29,6 @@ export const CircularProgressWithLabel = ({
           style={{
             fontSize: 28,
             color,
-            fontFamily: "josefin-sans, sans-serif",
           }}
         >{`${Math.round(props.value)}`}</Typography>
       </Box>


### PR DESCRIPTION
I used what was done [here](https://github.com/bamlab/react-native-flipper-performance-monitor/blob/master/flipper-desktop/src/components/CircularProgressWithLabel.tsx).

There is a problem with `josefin-sans` font-family. See [this issue](https://github.com/google/fonts/issues/3348).

| Before | After |
| ------ | ----- |
| <img width="105" alt="image" src="https://user-images.githubusercontent.com/40902940/190934996-bf157673-c3c1-47a7-91fe-44c1986e4582.png"> | <img width="111" alt="image" src="https://user-images.githubusercontent.com/40902940/190934976-6b128b8d-851e-4029-a896-cef0da01f7f4.png"> |