### PR TITLE
feat(cppProfiler): throw an error if SDK version is less than 24

### DIFF
--- a/packages/android-performance-profiler/src/commands/cppProfiler.ts
+++ b/packages/android-performance-profiler/src/commands/cppProfiler.ts
@@ -35,6 +35,17 @@ const stopATrace = () => {
 };
 
 export const ensureCppProfilerIsInstalled = () => {
+  const sdkVersion = parseInt(
+    executeCommand("adb shell getprop ro.build.version.sdk"),
+    10
+  );
+
+  if (sdkVersion < 24) {
+    throw new Error(
+      `Your Android version (sdk API level ${sdkVersion}) is not supported. Supported versions > 23.`
+    );
+  }
+
   if (!hasInstalledProfiler) {
     const abi = getAbi();
     Logger.info(`Installing C++ profiler for ${abi} architecture`);


### PR DESCRIPTION
It would seem that Android < 7 is not supported by the tool. We throw an error if the SDK version is less than 24. 

Issue: https://github.com/bamlab/android-performance-profiler/issues/34 

<img width="755" alt="image" src="https://user-images.githubusercontent.com/63585162/196173354-de9a6782-9f6c-4756-9ede-8a0fbdc2e08a.png">
