### PR TITLE
fix(e2e): fail command if e2e test fails on linux

### DIFF
--- a/packages/e2e-performance/src/executeAsync.ts
+++ b/packages/e2e-performance/src/executeAsync.ts
@@ -16,7 +16,7 @@ export const executeAsync = (command: string) => {
   const child = spawn("script", [
     "-q",
     "/dev/null",
-    ...(isMacOs ? command.split(" ") : ["-c", command]),
+    ...(isMacOs ? command.split(" ") : ["-e", "-c", command]),
   ]);
 
   return new Promise((resolve) => {


### PR DESCRIPTION
Now both macOS and ubuntu behave the same when testCommand throws error

![image](https://user-images.githubusercontent.com/4534323/206527262-2289a247-473e-42d8-abb9-957161429911.png)
